### PR TITLE
oauth-rp: wrong HTTP method (GET vs POST)

### DIFF
--- a/oauth/src/main/java/pl/edu/icm/unity/oauth/rp/verificator/MitreTokenVerificator.java
+++ b/oauth/src/main/java/pl/edu/icm/unity/oauth/rp/verificator/MitreTokenVerificator.java
@@ -49,7 +49,7 @@ public class MitreTokenVerificator implements TokenVerificatorProtocol
 	{
 		String verificationEndpoint = config.getValue(OAuthRPProperties.VERIFICATION_ENDPOINT);
 		
-		HTTPRequest httpReqRaw = new HTTPRequest(Method.GET, new URL(verificationEndpoint));
+		HTTPRequest httpReqRaw = new HTTPRequest(Method.POST, new URL(verificationEndpoint));
 		
 		StringBuilder queryB = new StringBuilder();
 		queryB.append("client_id=").append(URLEncoder.encode(config.getValue(OAuthRPProperties.CLIENT_ID), 

--- a/oauth/src/main/java/pl/edu/icm/unity/oauth/rp/verificator/MitreTokenVerificator.java
+++ b/oauth/src/main/java/pl/edu/icm/unity/oauth/rp/verificator/MitreTokenVerificator.java
@@ -97,7 +97,8 @@ public class MitreTokenVerificator implements TokenVerificatorProtocol
 			{
 				String scopes = (String) entry.getValue();
 				for (String s: scopes.split(" "))
-					scope.add(s);
+					if (s != null && !"".equals(s))
+						scope.add(s);
 			} else if ("active".equals(entry.getKey()))
 			{
 				valid = Boolean.parseBoolean(entry.getValue().toString());

--- a/oauth/src/main/java/pl/edu/icm/unity/oauth/rp/verificator/MitreTokenVerificator.java
+++ b/oauth/src/main/java/pl/edu/icm/unity/oauth/rp/verificator/MitreTokenVerificator.java
@@ -13,6 +13,7 @@ import java.util.Map.Entry;
 
 import org.apache.logging.log4j.Logger;
 
+import com.nimbusds.jose.util.Base64;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest.Method;
@@ -50,6 +51,9 @@ public class MitreTokenVerificator implements TokenVerificatorProtocol
 		String verificationEndpoint = config.getValue(OAuthRPProperties.VERIFICATION_ENDPOINT);
 		
 		HTTPRequest httpReqRaw = new HTTPRequest(Method.POST, new URL(verificationEndpoint));
+
+		String auth = config.getValue(OAuthRPProperties.CLIENT_ID) + ":" + config.getValue(OAuthRPProperties.CLIENT_SECRET);
+		httpReqRaw.setAuthorization("Basic " + Base64.encode(auth));
 		
 		StringBuilder queryB = new StringBuilder();
 		queryB.append("client_id=").append(URLEncoder.encode(config.getValue(OAuthRPProperties.CLIENT_ID), 


### PR DESCRIPTION
According to https://tools.ietf.org/html/draft-ietf-oauth-introspection-00

The request needs to be made with POST since GET is optional.

This fixes integration with Keycloak.