### PR TITLE
fix nullpointer exception when profile contains 'null' string values

### DIFF
--- a/oauth/src/main/java/pl/edu/icm/unity/oauth/client/profile/ProfileFetcherUtils.java
+++ b/oauth/src/main/java/pl/edu/icm/unity/oauth/client/profile/ProfileFetcherUtils.java
@@ -42,6 +42,9 @@ public class ProfileFetcherUtils
 			if (entry.getValue() == null)
 				continue;
 			Object value = JSONValue.parse(entry.getValue().toString());
+			if (value==null)
+				continue;
+			
 			if (value instanceof JSONObject)
 			{
 				ret.put(entry.getKey(), Arrays.asList(value.toString()));

--- a/oauth/src/test/java/pl/edu/icm/unity/oauth/client/profile/ProfileFetcherTest.java
+++ b/oauth/src/test/java/pl/edu/icm/unity/oauth/client/profile/ProfileFetcherTest.java
@@ -12,6 +12,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.text.ParseException;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import org.junit.Test;
@@ -20,9 +22,20 @@ import com.nimbusds.jose.util.JSONObjectUtils;
 
 import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
+import net.minidev.json.parser.JSONParser;
 
 public class ProfileFetcherTest
 {
+	
+	@Test
+	public void testHandleNullValues() throws Exception {
+		String s = "{\"test-field\": \"null\"}";
+		JSONParser p = new JSONParser(JSONParser.MODE_RFC4627);
+		JSONObject o = (JSONObject)p.parse(s);
+		Map<String,List<String>> m = ProfileFetcherUtils.convertToAttributes(o);
+		assertThat(m.size(), is(0));
+	}
+	
 
 	@Test
 	public void shouldResolveToJsonObjects() throws ParseException, IOException


### PR DESCRIPTION
Hi guys,

We ran into a small issue with parsing the OAuth profile info from a third party OIDC server (HBP Keycloak). When the profile contained 'null' values, e.g.
{
 "foo": "null",
} 
the ProfileFetcherUtils runs into an NPE
This commit fixes that.