### PR TITLE
Allow to set group's display name upon group creation

### DIFF
--- a/documentation/src/main/rest-api/rest-api-v1.txt
+++ b/documentation/src/main/rest-api/rest-api-v1.txt
@@ -291,9 +291,11 @@ Output structure:
 === Create group
 
 +@Path("/group/{groupPath}")+ +
++@QueryParam("displayedName")+ +
 +@POST+ +
 
-Creates a new group. The created group will be empty.
+Creates a new group. The created group will be empty. The optional +displayedName+ query parameter can be use to
+set group's default displayed name.
 
 
 === Delete groups

--- a/rest-admin/src/main/java/pl/edu/icm/unity/restadm/RESTAdmin.java
+++ b/rest-admin/src/main/java/pl/edu/icm/unity/restadm/RESTAdmin.java
@@ -429,10 +429,11 @@ public class RESTAdmin implements RESTAdminHandler
 	
 	@Path("/group/{groupPath}")
 	@POST
-	public void addGroup(@PathParam("groupPath") String group) throws EngineException, JsonProcessingException
+	public void addGroup(@PathParam("groupPath") String group,
+		 @QueryParam("displayedName") String displayedName) throws EngineException, JsonProcessingException
 	{
 		log.debug("addGroup " + group);
-		Group toAdd = new Group(group);
+		Group toAdd = new Group(group, displayedName);
 		groupsMan.addGroup(toAdd);
 	}
 

--- a/types-api/src/main/java/pl/edu/icm/unity/types/basic/Group.java
+++ b/types-api/src/main/java/pl/edu/icm/unity/types/basic/Group.java
@@ -69,8 +69,15 @@ public class Group extends I18nDescribedObject implements NamedObject
 
 	public Group(String path)
 	{
+		this(path, null);
+    }
+
+	public Group(String path, String requestedDisplayedName)
+	{
 		setPath(path);
 		displayedName = new I18nString(toString());
+		if (requestedDisplayedName != null)
+			displayedName.addValue("en", requestedDisplayedName);
 		description = new I18nString();
 		delegationConfiguration = new GroupDelegationConfiguration(false);
 		publicGroup = false;


### PR DESCRIPTION
It is nice to have a way to set a display name for a newly created group.