### PR TITLE
Fix: missing check box for choosing OIDC mode for user profile retrieval

### DIFF
--- a/oauth/src/main/java/pl/edu/icm/unity/oauth/rp/web/OAuthRPAuthenticatorEditor.java
+++ b/oauth/src/main/java/pl/edu/icm/unity/oauth/rp/web/OAuthRPAuthenticatorEditor.java
@@ -11,6 +11,7 @@ import com.vaadin.data.Binder;
 import com.vaadin.data.ValidationResult;
 import com.vaadin.data.converter.StringToIntegerConverter;
 import com.vaadin.server.Sizeable.Unit;
+import com.vaadin.ui.CheckBox;
 import com.vaadin.ui.ComboBox;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.FormLayout;
@@ -198,7 +199,11 @@ class OAuthRPAuthenticatorEditor extends BaseAuthenticatorEditor implements Auth
 		clientHttpMethodForProfileAccess.setEmptySelectionAllowed(false);
 		configBinder.forField(clientHttpMethodForProfileAccess).bind("clientHttpMethodForProfileAccess");
 		advanced.addComponent(clientHttpMethodForProfileAccess);		
-		
+
+		CheckBox openIdMode = new CheckBox(msg.getMessage("OAuthRPAuthenticatorEditor.openIdMode"));
+		configBinder.forField(openIdMode).bind("openIdMode");
+		advanced.addComponent(openIdMode);
+
 		return new CollapsibleLayout(msg.getMessage("OAuthRPAuthenticatorEditor.advanced"), advanced);
 	}
 

--- a/oauth/src/main/resources/messages/oauth/messages.properties
+++ b/oauth/src/main/resources/messages/oauth/messages.properties
@@ -151,6 +151,7 @@ OAuthRPAuthenticatorEditor.clientTrustStore=HTTPS client truststore:
 OAuthRPAuthenticatorEditor.clientHttpMethodForProfileAccess=HTTP method for profile access:
 OAuthRPAuthenticatorEditor.clientAuthenticationMode=Client authentication mode:
 OAuthRPAuthenticatorEditor.clientAuthenticationModeForProfile=Client authentication mode for profile access:
+OAuthRPAuthenticatorEditor.openIdMode=Enable OIDC mode for user profile retrieval
 
 Verificator.oauth2=OAuth 2 interactive (act as Client)
 Verificator.oauth-rp=OAuth 2 headless (act as Resource Provider)


### PR DESCRIPTION
hi! 

I found that there is a missing console GUI element to set the "openidConnectMode" for the oauth-rp authenticator which makes it a bit hard to change this setting :-) This change fixes that, please review. 

Best regards,
Bernd