### PR TITLE
UY-1580: Fix cached IdP logo replacement

### DIFF
--- a/saml/src/main/java/pl/edu/icm/unity/saml/metadata/cfg/AsyncExternalLogoFileDownloader.java
+++ b/saml/src/main/java/pl/edu/icm/unity/saml/metadata/cfg/AsyncExternalLogoFileDownloader.java
@@ -70,13 +70,13 @@ public class AsyncExternalLogoFileDownloader
 	}
 
 	@SuppressWarnings("unchecked")
-	public void downloadLogoFilesAsync(EntitiesDescriptorDocument entitiesDescriptorDocument, String httpsTruststore)
+	public CompletableFuture<Void> downloadLogoFilesAsync(EntitiesDescriptorDocument entitiesDescriptorDocument, String httpsTruststore)
 	{
 		String federationId = entitiesDescriptorDocument.getEntitiesDescriptor().getID();
 		if (!currentlyDownloadingFederation.add(federationId))
 		{
 			log.info("Logos of federation {} are being downloaded, won't start a new downloading process", federationId);
-			return;
+			return CompletableFuture.completedFuture(null);
 		}
 		CompletableFuture<Set<String>>[] savedFilesNamesFutures;
 		try
@@ -97,9 +97,9 @@ public class AsyncExternalLogoFileDownloader
 		{
 			currentlyDownloadingFederation.remove(federationId);
 			log.error("This exception occurred when metadata has been converted to TrustedIdPs", e);
-			return;
+			return CompletableFuture.completedFuture(null);
 		}
-		CompletableFuture.allOf(savedFilesNamesFutures)
+		return CompletableFuture.allOf(savedFilesNamesFutures)
 			.thenRunAsync(
 				() -> cleanUp(entitiesDescriptorDocument, savedFilesNamesFutures),
 				executorService)
@@ -152,7 +152,7 @@ public class AsyncExternalLogoFileDownloader
 		{
 			paths.filter(Files::isRegularFile)
 					.filter(path -> savedFilesBasedNames.stream().noneMatch(name -> path.getFileName().toString().startsWith(name)))
-					.forEach(path -> path.toFile().delete());
+					.forEach(AsyncExternalLogoFileDownloader::deleteCachedLogoFileIfExists);
 		}
 	}
 
@@ -251,7 +251,18 @@ public class AsyncExternalLogoFileDownloader
 			paths.filter(Files::isRegularFile)
 					.filter(path -> path.getFileName().toString().startsWith(name + "."))
 					.filter(path -> !path.getFileName().toString().equals(currentFileName))
-					.forEach(path -> path.toFile().delete());
+					.forEach(AsyncExternalLogoFileDownloader::deleteCachedLogoFileIfExists);
+		}
+	}
+
+	private static void deleteCachedLogoFileIfExists(Path path)
+	{
+		try
+		{
+			Files.deleteIfExists(path);
+		} catch (IOException e)
+		{
+			log.warn("Failed to delete cached logo file {}", path, e);
 		}
 	}
 

--- a/saml/src/main/java/pl/edu/icm/unity/saml/metadata/cfg/AsyncExternalLogoFileDownloader.java
+++ b/saml/src/main/java/pl/edu/icm/unity/saml/metadata/cfg/AsyncExternalLogoFileDownloader.java
@@ -5,8 +5,6 @@
 
 package pl.edu.icm.unity.saml.metadata.cfg;
 
-import org.apache.commons.io.FileExistsException;
-import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Component;
 
@@ -31,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -225,15 +224,34 @@ public class AsyncExternalLogoFileDownloader
 		Files.write(imageFile.toPath(), decoded);
 		File pointerFile = createFile(catalog, name);
 		Files.write(pointerFile.toPath(), extension.getBytes(StandardCharsets.UTF_8));
+		Path finalImagePath = Path.of(workspaceDir, catalog, name + "." + extension);
+		Path finalPointerPath = Path.of(workspaceDir, catalog, name);
 		try
 		{
-			FileUtils.moveFile(imageFile, new File(Path.of(workspaceDir, catalog, name + "." + extension).toUri()));
-			FileUtils.moveFile(pointerFile, new File(Path.of(workspaceDir, catalog, name).toUri()));
+			Files.createDirectories(finalImagePath.getParent());
+			Files.move(imageFile.toPath(), finalImagePath, StandardCopyOption.REPLACE_EXISTING);
+			Files.move(pointerFile.toPath(), finalPointerPath, StandardCopyOption.REPLACE_EXISTING);
+			removeObsoleteLogoFiles(catalog, name, extension);
 		}
-		catch (FileExistsException e)
+		finally
 		{
 			imageFile.delete();
 			pointerFile.delete();
+		}
+	}
+
+	private void removeObsoleteLogoFiles(String catalog, String name, String currentExtension) throws IOException
+	{
+		Path finalDir = Path.of(workspaceDir, catalog);
+		if(!Files.exists(finalDir))
+			return;
+		String currentFileName = name + "." + currentExtension;
+		try (Stream<Path> paths = Files.list(finalDir))
+		{
+			paths.filter(Files::isRegularFile)
+					.filter(path -> path.getFileName().toString().startsWith(name + "."))
+					.filter(path -> !path.getFileName().toString().equals(currentFileName))
+					.forEach(path -> path.toFile().delete());
 		}
 	}
 

--- a/saml/src/test/java/pl/edu/icm/unity/saml/metadata/cfg/AsyncExternalLogoFileDownloadAndFetchFlowTest.java
+++ b/saml/src/test/java/pl/edu/icm/unity/saml/metadata/cfg/AsyncExternalLogoFileDownloadAndFetchFlowTest.java
@@ -77,29 +77,22 @@ public class AsyncExternalLogoFileDownloadAndFetchFlowTest extends DBIntegration
 	}
 
 	@Test
-	public void shouldReplaceCachedLogoWhenExtensionChanges()
+	public void shouldReplaceCachedLogoWhenExtensionChanges() throws IOException
 	{
 		EntitiesDescriptorDocument oldMetadata = loadMetadata("src/test/resources/metadata-of-signed-response.xml");
 		EntitiesDescriptorDocument newMetadata = loadMetadataWithLogoMimeType("image/jpeg");
 		TrustedIdPKey trustedIdPKey = TrustedIdPKey.metadataEntity("http://centos6-unity1:8080/simplesaml/saml2/idp/metadata.php", 1);
 		String baseName = LogoFilenameUtils.getLogoFileBasename(trustedIdPKey, "en");
 
-		fileDownloader.downloadLogoFilesAsync(oldMetadata, null);
-		Awaitility.await()
-				.atMost(Durations.TEN_SECONDS)
-				.untilAsserted(() -> assertThat(getLogoFile(oldMetadata, baseName, "png")).isFile());
+		fileDownloader.downloadLogoFilesAsync(oldMetadata, null).join();
+		assertThat(getLogoFile(oldMetadata, baseName, "png")).isFile();
 
-		fileDownloader.downloadLogoFilesAsync(newMetadata, null);
+		fileDownloader.downloadLogoFilesAsync(newMetadata, null).join();
 
-		Awaitility.await()
-				.atMost(Durations.TEN_SECONDS)
-				.untilAsserted(() ->
-				{
-					assertThat(getLogoFile(newMetadata, baseName, "jpeg")).isFile();
-					assertThat(getLogoFile(newMetadata, baseName, "png")).doesNotExist();
-					assertThat(Files.readString(getLogoPointer(newMetadata, baseName).toPath())).isEqualTo("jpeg");
-					checkIfStagingCleaned(newMetadata.getEntitiesDescriptor().getID());
-				});
+		assertThat(getLogoFile(newMetadata, baseName, "jpeg")).isFile();
+		assertThat(getLogoFile(newMetadata, baseName, "png")).doesNotExist();
+		assertThat(Files.readString(getLogoPointer(newMetadata, baseName).toPath())).isEqualTo("jpeg");
+		checkIfStagingCleaned(newMetadata.getEntitiesDescriptor().getID());
 	}
 
 	private static void createOldFiles(String oldFileName, String oldFileExtension, EntitiesDescriptorDocument metadata)

--- a/saml/src/test/java/pl/edu/icm/unity/saml/metadata/cfg/AsyncExternalLogoFileDownloadAndFetchFlowTest.java
+++ b/saml/src/test/java/pl/edu/icm/unity/saml/metadata/cfg/AsyncExternalLogoFileDownloadAndFetchFlowTest.java
@@ -17,10 +17,12 @@ import xmlbeans.org.oasis.saml2.metadata.EntitiesDescriptorDocument;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Objects;
 import java.util.Optional;
 
 import static org.apache.commons.io.FileUtils.deleteDirectory;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class AsyncExternalLogoFileDownloadAndFetchFlowTest extends DBIntegrationTestBase
 {
@@ -74,6 +76,32 @@ public class AsyncExternalLogoFileDownloadAndFetchFlowTest extends DBIntegration
 				});
 	}
 
+	@Test
+	public void shouldReplaceCachedLogoWhenExtensionChanges()
+	{
+		EntitiesDescriptorDocument oldMetadata = loadMetadata("src/test/resources/metadata-of-signed-response.xml");
+		EntitiesDescriptorDocument newMetadata = loadMetadataWithLogoMimeType("image/jpeg");
+		TrustedIdPKey trustedIdPKey = TrustedIdPKey.metadataEntity("http://centos6-unity1:8080/simplesaml/saml2/idp/metadata.php", 1);
+		String baseName = LogoFilenameUtils.getLogoFileBasename(trustedIdPKey, "en");
+
+		fileDownloader.downloadLogoFilesAsync(oldMetadata, null);
+		Awaitility.await()
+				.atMost(Durations.TEN_SECONDS)
+				.untilAsserted(() -> assertThat(getLogoFile(oldMetadata, baseName, "png")).isFile());
+
+		fileDownloader.downloadLogoFilesAsync(newMetadata, null);
+
+		Awaitility.await()
+				.atMost(Durations.TEN_SECONDS)
+				.untilAsserted(() ->
+				{
+					assertThat(getLogoFile(newMetadata, baseName, "jpeg")).isFile();
+					assertThat(getLogoFile(newMetadata, baseName, "png")).doesNotExist();
+					assertThat(Files.readString(getLogoPointer(newMetadata, baseName).toPath())).isEqualTo("jpeg");
+					checkIfStagingCleaned(newMetadata.getEntitiesDescriptor().getID());
+				});
+	}
+
 	private static void createOldFiles(String oldFileName, String oldFileExtension, EntitiesDescriptorDocument metadata)
 	{
 		try
@@ -115,11 +143,35 @@ public class AsyncExternalLogoFileDownloadAndFetchFlowTest extends DBIntegration
 			throw new IllegalStateException("Staging catalog not clean");
 	}
 
+	private File getLogoFile(EntitiesDescriptorDocument metadata, String baseName, String extension)
+	{
+		return new File("target/workspace/downloadedIdPLogos/"
+				+ LogoFilenameUtils.federationDirName(metadata.getEntitiesDescriptor().getID()) + "/" + baseName + "." + extension);
+	}
+
+	private File getLogoPointer(EntitiesDescriptorDocument metadata, String baseName)
+	{
+		return new File("target/workspace/downloadedIdPLogos/"
+				+ LogoFilenameUtils.federationDirName(metadata.getEntitiesDescriptor().getID()) + "/" + baseName);
+	}
+
 	private EntitiesDescriptorDocument loadMetadata(String path)
 	{
 		try
 		{
 			return EntitiesDescriptorDocument.Factory.parse(new File(path));
+		} catch (XmlException | IOException e)
+		{
+			throw new RuntimeException("Can't load test XML", e);
+		}
+	}
+
+	private EntitiesDescriptorDocument loadMetadataWithLogoMimeType(String mimeType)
+	{
+		try
+		{
+			String metadata = Files.readString(new File("src/test/resources/metadata-of-signed-response.xml").toPath());
+			return EntitiesDescriptorDocument.Factory.parse(metadata.replace("data:image/png", "data:" + mimeType));
 		} catch (XmlException | IOException e)
 		{
 			throw new RuntimeException("Can't load test XML", e);


### PR DESCRIPTION
## Summary
- Replace cached downloaded IdP logo files when the same logo key is fetched again with a different extension.
- Update the logo pointer file atomically with the new extension.
- Remove obsolete extension variants for the same logo basename.
- Add a regression test covering png -> jpeg replacement and stale file cleanup.

## Root cause
Downloaded IdP logos are stored as `<basename>.<extension>` with a separate `<basename>` pointer file containing the current extension. When the same IdP logo was downloaded again, `FileUtils.moveFile(...)` failed if the pointer file already existed. The old code caught `FileExistsException` and skipped the update, leaving the stale cached logo/pointer on disk. If the logo extension changed, the old extension variant was not removed.

## Fix
Use `Files.move(..., StandardCopyOption.REPLACE_EXISTING)` for both the logo file and pointer, then remove obsolete `<basename>.*` files except the current extension.

## Tests
- Verified RED before the fix:
  - `mvn -pl saml -am -Dtest=pl.edu.icm.unity.saml.metadata.cfg.AsyncExternalLogoFileDownloadAndFetchFlowTest#shouldReplaceCachedLogoWhenExtensionChanges -Dsurefire.failIfNoSpecifiedTests=false test -Dgpg.skip=true`
- Verified GREEN after the fix:
  - `mvn -pl saml -am -Dtest=pl.edu.icm.unity.saml.metadata.cfg.AsyncExternalLogoFileDownloadAndFetchFlowTest#shouldReplaceCachedLogoWhenExtensionChanges -Dsurefire.failIfNoSpecifiedTests=false test -Dgpg.skip=true -q`
  - `mvn -pl saml -am -Dtest=pl.edu.icm.unity.saml.metadata.cfg.AsyncExternalLogoFileDownloadAndFetchFlowTest -Dsurefire.failIfNoSpecifiedTests=false test -Dgpg.skip=true -q`
  - `mvn -pl saml -am -Dtest=pl.edu.icm.unity.saml.metadata.cfg.AsyncExternalLogoFileDownloaderTest,pl.edu.icm.unity.saml.sp.web.LogoExposingServiceTest -Dsurefire.failIfNoSpecifiedTests=false test -Dgpg.skip=true -q`
  - `mvn -pl saml test -Dgpg.skip=true -q`
  - `git diff --check`
  - `coderabbit doctor`
  - `coderabbit review --base upstream/dev --type committed --agent` (0 findings)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced logo caching with atomic file operations for more reliable downloads and updates
  * Automatic cleanup of obsolete cached logo files when logo format or MIME type changes
  * Improved metadata handling to prevent stale logo files from persisting in cache directories

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unity-idm/unity/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->