### PR TITLE
Update form layouts after project policy reset

### DIFF
--- a/engine/src/main/java/pl/edu/icm/unity/engine/utils/GroupDelegationConfigGeneratorImpl.java
+++ b/engine/src/main/java/pl/edu/icm/unity/engine/utils/GroupDelegationConfigGeneratorImpl.java
@@ -36,6 +36,7 @@ import pl.edu.icm.unity.base.registration.CredentialRegistrationParam;
 import pl.edu.icm.unity.base.registration.EnquiryForm;
 import pl.edu.icm.unity.base.registration.EnquiryFormBuilder;
 import pl.edu.icm.unity.base.registration.EnquiryFormNotifications;
+import pl.edu.icm.unity.base.registration.FormLayoutUtils;
 import pl.edu.icm.unity.base.registration.FormType;
 import pl.edu.icm.unity.base.registration.GroupRegistrationParam;
 import pl.edu.icm.unity.base.registration.ParameterRetrievalSettings;
@@ -426,6 +427,7 @@ public class GroupDelegationConfigGeneratorImpl implements GroupDelegationConfig
 			for (Long policyDocumentId : projectPolicyDocumentsIds) {
 				addPolicyParam(form.getPolicyAgreements(), policyDocumentId);
 			}
+			FormLayoutUtils.updateRegistrationFormLayout(form.getFormLayouts(), form);
 			regFormDB.update(form);
 		}
 		else if (formType.equals(FormType.ENQUIRY))
@@ -435,6 +437,7 @@ public class GroupDelegationConfigGeneratorImpl implements GroupDelegationConfig
 			for (Long policyDocumentId : projectPolicyDocumentsIds) {
 				addPolicyParam(form.getPolicyAgreements(), policyDocumentId);
 			}
+			FormLayoutUtils.updateEnquiryLayout(form.getLayout(), form);
 			enqFormDB.update(form);
 		}
 		

--- a/engine/src/test/java/pl/edu/icm/unity/engine/project/TestGroupDelegationConfigGenerator.java
+++ b/engine/src/test/java/pl/edu/icm/unity/engine/project/TestGroupDelegationConfigGenerator.java
@@ -8,6 +8,7 @@ package pl.edu.icm.unity.engine.project;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
@@ -269,6 +270,7 @@ public class TestGroupDelegationConfigGenerator extends TestProjectBase
 		assertThat(form.getLayout().getElements()).containsExactly(
 				new FormParameterElement(FormLayoutElement.GROUP, 0),
 				new FormParameterElement(FormLayoutElement.POLICY_AGREEMENT, 0));
+		verify(mockEnqFormDB).update(form);
 	}
 
 	@Test

--- a/engine/src/test/java/pl/edu/icm/unity/engine/project/TestGroupDelegationConfigGenerator.java
+++ b/engine/src/test/java/pl/edu/icm/unity/engine/project/TestGroupDelegationConfigGenerator.java
@@ -38,8 +38,12 @@ import pl.edu.icm.unity.base.policy_agreement.PolicyAgreementPresentationType;
 import pl.edu.icm.unity.base.registration.BaseFormNotifications;
 import pl.edu.icm.unity.base.registration.EnquiryForm;
 import pl.edu.icm.unity.base.registration.EnquiryFormBuilder;
+import pl.edu.icm.unity.base.registration.FormType;
 import pl.edu.icm.unity.base.registration.RegistrationForm;
 import pl.edu.icm.unity.base.registration.RegistrationFormBuilder;
+import pl.edu.icm.unity.base.registration.layout.FormLayout;
+import pl.edu.icm.unity.base.registration.layout.FormLayoutElement;
+import pl.edu.icm.unity.base.registration.layout.FormParameterElement;
 import pl.edu.icm.unity.base.translation.TranslationProfile;
 import pl.edu.icm.unity.base.translation.TranslationRule;
 import pl.edu.icm.unity.engine.api.translation.form.TranslatedRegistrationRequest.AutomaticRequestAction;
@@ -242,6 +246,29 @@ public class TestGroupDelegationConfigGenerator extends TestProjectBase
 
 		List<String> errors = generator.validateUpdateEnquiryForm("/A", "aenSuffix");
 		assertThat(errors.size()).isEqualTo(0);
+	}
+
+	@Test
+	public void shouldUpdateCustomEnquiryLayoutWhenProjectPoliciesAreReset() throws EngineException
+	{
+		when(mockPolicyDocumentDB.getByKey(2L)).thenReturn(new StoredPolicyDocument(2L, "Policy"));
+		EnquiryForm form = new EnquiryFormBuilder()
+				.withName("aenSuffix")
+				.withTargetGroups(new String[] { "/" })
+				.withType(EnquiryForm.EnquiryType.STICKY)
+				.withAddedGroupParam()
+				.withGroupPath("/A/?*/**")
+				.endGroupParam()
+				.withLayout(new FormLayout(List.of(new FormParameterElement(FormLayoutElement.GROUP, 0))))
+				.build();
+		when(mockEnqFormDB.get(eq("aenSuffix"))).thenReturn(form);
+
+		generator.resetFormsPolicies("aenSuffix", FormType.ENQUIRY, List.of(2L));
+
+		assertThat(form.getPolicyAgreements()).hasSize(1);
+		assertThat(form.getLayout().getElements()).containsExactly(
+				new FormParameterElement(FormLayoutElement.GROUP, 0),
+				new FormParameterElement(FormLayoutElement.POLICY_AGREEMENT, 0));
 	}
 
 	@Test


### PR DESCRIPTION
Summary
- Update stored registration/enquiry form layouts when project policy documents are reset on a form.
- Add a regression test for an enquiry form with a custom layout that initially lacks the policy-agreement element.

Root cause
- Project policy reset updated the form's `policyAgreements` list but did not update stored custom form layouts.
- If a custom enquiry layout was saved before/without the policy-agreement element, the policy stayed configured on the form but was not rendered to the user, so submitting the enquiry did not create `sys:policy-agreement-state`.

Fix
- Call `FormLayoutUtils.updateRegistrationFormLayout(...)` and `FormLayoutUtils.updateEnquiryLayout(...)` after resetting policy agreements.

Tests
- RED before fix: `mvn -pl engine -Dtest=TestGroupDelegationConfigGenerator#shouldUpdateCustomEnquiryLayoutWhenProjectPoliciesAreReset test -Dgpg.skip=true -q` failed because the custom layout contained only `GROUP_0`.
- GREEN after fix: same targeted test passed.
- Relevant tests: `mvn -pl engine -Dtest=TestGroupDelegationConfigGenerator,TestEnquiryPolicyAgreements test -Dgpg.skip=true -q` passed.
- `git diff --check` passed.
- CodeRabbit review against `upstream/dev`: no findings.

Manual verification
- Source review confirmed generated project registration and join-enquiry forms include project policy agreements.
- Source review confirmed policy rendering depends on the effective form layout containing `POLICY_AGREEMENT_n` elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Form layouts are now correctly refreshed when policy agreements are reset, ensuring proper structure in both registration and enquiry forms.

* **Tests**
  * Added test coverage for enquiry form layout updates to verify that policy elements are properly included in form structures when policies are reset.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unity-idm/unity/pull/116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->